### PR TITLE
Updates code to be compliant with r86; fix issue when textures have special HTML chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ Object.assign(MTLLoader.prototype, THREE.EventDispatcher.prototype, {
 
     var scope = this;
 
-    var loader = new THREE.XHRLoader( this.manager );
+    var loader = new THREE.FileLoader( this.manager );
     loader.setPath( this.path );
     loader.load( url, function ( text ) {
 

--- a/index.js
+++ b/index.js
@@ -357,7 +357,7 @@ MTLLoader.MaterialCreator.prototype = {
         return url;
       }
 
-      return baseUrl + url;
+      return baseUrl + encodeURIComponent(url);
     };
     
     function setMapForType ( mapType, value ) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/nascherman/three-mtl-loader#readme",
   "dependencies": {
-    "three": "^0.79.0"
+    "three": "^0.86.0"
   },
   "devDependencies": {
     "budo": "^8.3.0",


### PR DESCRIPTION
Since r85 the WebGLRenderer expects that each material have a onBeforeCompile method. Because three-mtl-loader is still referring r86, such method does not exist. So I have fixed the dependency to use version 0.86 and replaced the XHRLoader with FileLoader.

Another issue is when a texture use a name with special HTML characters like #. To fix that I added the encodeURIComponent when the url passed to resolveURL is not absolute.

 