### PR TITLE
Avasconcelos114 update three version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/nascherman/three-mtl-loader#readme",
   "dependencies": {
-    "three": "^0.95.0"
+    "three": "^0.97.0"
   },
   "devDependencies": {
     "budo": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/nascherman/three-mtl-loader#readme",
   "dependencies": {
-    "three": "^0.87.1"
+    "three": "^0.95.0"
   },
   "devDependencies": {
     "budo": "^8.3.0",


### PR DESCRIPTION
This should update threejs from r87.1 to r97 (latest release in the time of this PR submission).

It should fix a few issues caused by version mismatching.